### PR TITLE
Add section to the readme explaining how to enable non-JavaScript language highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,15 @@ To give the highlighter a window look in a directive mode, also don't forget to 
 In order to visually higlight your code, you need to select a theme from `./node_modules/vue-code-highlight/themes/` and import it somewhere into your component/application. These are just regular prism themes, so feel free to improvise.
 
 ![themes](/public/themes.png)
+
+## Other languages
+
+Any of the [supported languages](https://prismjs.com/index.html#supported-languages) in Prism may be used. To enable support
+for them, you must import them explicitly as well as Prism's markup templating.
+
+For example, to include PHP highlighting in your application:
+
+```jsx
+import 'prism-es6/components/prism-markup-templating';
+import 'prism-es6/components/prism-php';
+```


### PR DESCRIPTION
I came across #6 and thought I'd add a note to help others in future.